### PR TITLE
Optimize chunk splitting in gcode file transfers

### DIFF
--- a/cli/pppp.py
+++ b/cli/pppp.py
@@ -62,11 +62,8 @@ def pppp_send_file(api, fui, data):
 
     log.info("Sending file contents..")
     blocksize = 1024 * 32
-    chunks = cli.util.split_chunks(data, blocksize)
-    pos = 0
 
     with tqdm(unit="b", total=len(data), unit_scale=True, unit_divisor=1024) as bar:
-        for chunk in chunks:
+        for pos, chunk in cli.util.split_chunks(data, blocksize):
             api.aabb_request(chunk, frametype=FileTransfer.DATA, pos=pos)
-            pos += len(chunk)
             bar.update(len(chunk))

--- a/cli/util.py
+++ b/cli/util.py
@@ -104,12 +104,8 @@ def pretty_size(size):
 
 
 def split_chunks(data, chunksize):
-    data = data[:]
-    res = []
-    while data:
-        res.append(data[:chunksize])
-        data = data[chunksize:]
-    return res
+    for offset in range(0, len(data), chunksize):
+        yield offset, data[offset:offset+chunksize]
 
 
 def parse_http_bool(str):

--- a/web/service/filetransfer.py
+++ b/web/service/filetransfer.py
@@ -41,12 +41,8 @@ class FileTransferService(Service):
 
             log.info("Sending file contents..")
             blocksize = 1024 * 32
-            chunks = cli.util.split_chunks(data, blocksize)
-            pos = 0
-
-            for chunk in chunks:
+            for pos, chunk in cli.util.split_chunks(data, blocksize):
                 self.api_aabb_request(api, FileTransfer.DATA, chunk, pos)
-                pos += len(chunk)
 
             log.info("File upload complete. Requesting print start of job.")
 


### PR DESCRIPTION
Instead of copying the whole gcode file data and then splitting it into 32 KB chunks (2nd copy), use a generator function which emits the chunks along with the current offset to be used in the AABB request.